### PR TITLE
Fix demonitor flush #716

### DIFF
--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -110,14 +110,14 @@ Context *context_new(GlobalContext *glb)
 void context_destroy(Context *ctx)
 {
     // Another process can get an access to our mailbox until this point.
-    struct ListHead *processes_table_list = synclist_wrlock(&glb->processes_table);
+    struct ListHead *processes_table_list = synclist_wrlock(&ctx->global->processes_table);
 
     list_remove(&ctx->processes_table_head);
 
     // When monitor message is sent, process is no longer in the table.
     context_monitors_handle_terminate(ctx);
 
-    synclist_unlock(&glb->processes_table);
+    synclist_unlock(&ctx->global->processes_table);
 
     // Ensure process is not registered
     globalcontext_maybe_unregister_process_id(ctx->global, ctx->process_id);

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -110,13 +110,18 @@ Context *context_new(GlobalContext *glb)
 void context_destroy(Context *ctx)
 {
     // Another process can get an access to our mailbox until this point.
-    synclist_remove(&ctx->global->processes_table, &ctx->processes_table_head);
+    struct ListHead *processes_table_list = synclist_wrlock(&glb->processes_table);
+
+    list_remove(&ctx->processes_table_head);
+
+    // When monitor message is sent, process is no longer in the table.
+    context_monitors_handle_terminate(ctx);
+
+    synclist_unlock(&glb->processes_table);
 
     // Ensure process is not registered
     globalcontext_maybe_unregister_process_id(ctx->global, ctx->process_id);
 
-    // When monitor message is sent, process is no longer in the table.
-    context_monitors_handle_terminate(ctx);
 
     // Any other process released our mailbox, so we can clear it.
     mailbox_destroy(&ctx->mailbox, &ctx->heap);
@@ -288,13 +293,10 @@ static void context_monitors_handle_terminate(Context *ctx)
             erl_nif_env_partial_init_from_globalcontext(&env, glb);
             refc->resource_type->down(&env, resource, &ctx->process_id, &monitor->ref_ticks);
 
-            struct ListHead *processes_table_list = synclist_wrlock(&glb->processes_table);
-            UNUSED(processes_table_list);
             list_remove(&resource_monitor->resource_list_head);
-            synclist_unlock(&glb->processes_table);
         } else {
             int local_process_id = term_to_local_process_id(monitor->monitor_obj);
-            Context *target = globalcontext_get_process_lock(glb, local_process_id);
+            Context *target = globalcontext_get_process_nolock(glb, local_process_id);
             if (IS_NULL_PTR(target)) {
                 // TODO: we should scan for existing monitors when a context is destroyed
                 // otherwise memory might be wasted for long living processes
@@ -345,7 +347,6 @@ static void context_monitors_handle_terminate(Context *ctx)
 
                 mailbox_send(target, info_tuple);
             }
-            globalcontext_get_process_unlock(glb, target);
         }
         free(monitor);
     }

--- a/src/libAtomVM/context.c
+++ b/src/libAtomVM/context.c
@@ -122,7 +122,6 @@ void context_destroy(Context *ctx)
     // Ensure process is not registered
     globalcontext_maybe_unregister_process_id(ctx->global, ctx->process_id);
 
-
     // Any other process released our mailbox, so we can clear it.
     mailbox_destroy(&ctx->mailbox, &ctx->heap);
 

--- a/src/libAtomVM/opcodesswitch.h
+++ b/src/libAtomVM/opcodesswitch.h
@@ -1107,6 +1107,9 @@ COLD_FUNC static void dump(Context *ctx)
     mailbox_crashdump(ctx);
 
     fprintf(stderr, "\n\nMonitors\n--------\n");
+    // Lock processes table to make sure any dying process will not modify monitors
+    struct ListHead *processes_table = synclist_rdlock(&ctx->global->processes_table);
+    UNUSED(processes_table);
     struct ListHead *item;
     LIST_FOR_EACH (item, &ctx->monitors_head) {
         struct Monitor *monitor = GET_LIST_ENTRY(item, struct Monitor, monitor_list_head);
@@ -1123,7 +1126,7 @@ COLD_FUNC static void dump(Context *ctx)
         term_display(stderr, term_from_local_process_id(ctx->process_id), ctx);
         fprintf(stderr, "\n");
     }
-
+    synclist_unlock(&ctx->global->processes_table);
     fprintf(stderr, "\n\n**End Of Crash Report**\n");
 }
 


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
