### PR TITLE
Fix flappiness of test_refc_binaries

### DIFF
--- a/tests/erlang_tests/test_refc_binaries.erl
+++ b/tests/erlang_tests/test_refc_binaries.erl
@@ -236,7 +236,6 @@ run_test(Fun) ->
     end.
 
 execute(Pid, Fun) ->
-    erlang:garbage_collect(),
     Result =
         try
             Fun(),
@@ -245,6 +244,7 @@ execute(Pid, Fun) ->
             _:Error ->
                 {error, Error}
         end,
+    erlang:garbage_collect(),
     Pid ! Result.
 
 id(X) -> X.


### PR DESCRIPTION
In some circumstances, `erlang:memory(binary)` returns the space used by a refc binary from the previous test. Ensure everything is cleaned up by calling gc before sending result.

Monitor wouldn’t help because monitor message is sent before mso is swept.

Also remove useless gc before the test as the process was freshly spawned.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
