### PR TITLE
Fix flappiness of test_sub_binaries

### DIFF
--- a/tests/erlang_tests/test_sub_binaries.erl
+++ b/tests/erlang_tests/test_sub_binaries.erl
@@ -355,6 +355,7 @@ execute(Pid, Fun) ->
             _:Error ->
                 {error, Error}
         end,
+    erlang:garbage_collect(),
     Pid ! Result.
 
 id(X) -> X.


### PR DESCRIPTION
See #723 and #724

We need to garbage collect at the end of each test to make sure ref counted binaries are disposed before `erlang:memory(binary)` is called in next test.

We cannot rely on monitors because the DOWN message is currently sent before the mso list is processed and references are decremented.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
