### PR TITLE
Allow usage by external tools

### DIFF
--- a/libs/jit/rebar.conf
+++ b/libs/jit/rebar.conf
@@ -1,0 +1,35 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2020 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+{erl_opts, [debug_info]}.
+{deps, []}.
+{plugins, [rebar3_ex_doc]}.
+
+{shell, [
+    {apps, [jit]}
+]}.
+{ex_doc, [
+    {version, "0.1.0"},
+    {source_url, "https://github.com/atomvm/AtomVM"},
+    {extras, []},
+    {main, "atomvm"},
+    {output, "doc"},
+    {api_reference, true}
+]}.

--- a/libs/jit/src/jit.app.src
+++ b/libs/jit/src/jit.app.src
@@ -1,0 +1,35 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2025 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+{application, jit,
+ [{description, "AtomVM jit"},
+  {vsn, "0.1.0"},
+  {registered, []},
+  {applications,
+   [kernel,
+    stdlib
+   ]},
+  {env,[]},
+  {modules, []},
+
+  {maintainers, []},
+  {licenses, ["Apache 2.0"]},
+  {links, [{"GitHub", "https://github.com/atomvm/AtomVM/"}]}
+ ]}.

--- a/libs/jit/src/jit_precompile.erl
+++ b/libs/jit/src/jit_precompile.erl
@@ -19,7 +19,7 @@
 %
 -module(jit_precompile).
 
--export([start/0]).
+-export([start/0, compile/3]).
 
 -include_lib("jit.hrl").
 


### PR DESCRIPTION
Adds `jit_precompile:compile/3` to exports and adds support for building with rebar3 for consumption by downstream tools like atomvm_rebar3_plugin.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
