### PR TITLE
Fix missing mul_reg/3 in armv6m and riscv32 backends

### DIFF
--- a/libs/jit/src/jit_armv6m.erl
+++ b/libs/jit/src/jit_armv6m.erl
@@ -66,6 +66,7 @@
     add/3,
     sub/3,
     mul/3,
+    mul_reg/3,
     decrement_reductions_and_maybe_schedule_next/1,
     call_or_schedule_next/2,
     call_only_or_schedule_next/2,
@@ -3528,6 +3529,16 @@ mul(
     State1#state{
         stream = Stream2, available_regs = State1#state.available_regs bor TempBit, regs = Regs1
     }.
+
+%% Register-register multiply: DestReg = DestReg * SrcReg
+-spec mul_reg(state(), armv6m_register(), armv6m_register()) -> state().
+mul_reg(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, DestReg, SrcReg
+) ->
+    I = jit_armv6m_asm:muls(DestReg, SrcReg),
+    Stream1 = StreamModule:append(Stream0, I),
+    Regs1 = jit_regs:invalidate_reg(Regs0, DestReg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 %%
 %% Analysis of AArch64 pattern and ARM Thumb mapping:

--- a/libs/jit/src/jit_riscv32.erl
+++ b/libs/jit/src/jit_riscv32.erl
@@ -65,6 +65,7 @@
     add/3,
     sub/3,
     mul/3,
+    mul_reg/3,
     decrement_reductions_and_maybe_schedule_next/1,
     call_or_schedule_next/2,
     call_only_or_schedule_next/2,
@@ -3200,6 +3201,16 @@ mul(
         available_regs = State1#state.available_regs bor reg_bit(Temp),
         regs = Regs1
     }.
+
+%% Register-register multiply: DestReg = DestReg * SrcReg
+-spec mul_reg(state(), riscv32_register(), riscv32_register()) -> state().
+mul_reg(
+    #state{stream_module = StreamModule, stream = Stream0, regs = Regs0} = State, DestReg, SrcReg
+) ->
+    I = jit_riscv32_asm:mul(DestReg, DestReg, SrcReg),
+    Stream1 = StreamModule:append(Stream0, I),
+    Regs1 = jit_regs:invalidate_reg(Regs0, DestReg),
+    State#state{stream = Stream1, regs = Regs1}.
 
 %%
 %% Analysis of AArch64 pattern and RISC-V32 implementation:


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later