### PR TITLE
Fix resource double-free race between fire_monitor and destruction

### DIFF
--- a/src/libAtomVM/globalcontext.c
+++ b/src/libAtomVM/globalcontext.c
@@ -240,7 +240,7 @@ COLD_FUNC void globalcontext_destroy(GlobalContext *glb)
         struct RefcBinary *refc = GET_LIST_ENTRY(item, struct RefcBinary, head);
 #ifndef NDEBUG
         if (refc->resource_type) {
-            fprintf(stderr, "Warning, dangling resource of type %s, ref_count = %d, data = %p\n", refc->resource_type->name, (int) refc->ref_count, (void *) refc->data);
+            fprintf(stderr, "Warning, dangling resource of type %s, ref_count = %d, data = %p\n", refc->resource_type->name, (int) refc_binary_get_refcount(refc), (void *) refc->data);
         } else {
             fprintf(stderr, "Warning, dangling refc binary, ref_count = %d\n", (int) refc->ref_count);
         }

--- a/src/libAtomVM/refc_binary.c
+++ b/src/libAtomVM/refc_binary.c
@@ -60,33 +60,37 @@ struct RefcBinary *refc_binary_from_data(void *ptr)
 
 void refc_binary_increment_refcount(struct RefcBinary *refc)
 {
-    refc->ref_count++;
+    refc_binary_add_refcount(refc, 1);
 }
 
 bool refc_binary_decrement_refcount(struct RefcBinary *refc, struct GlobalContext *global)
 {
-    if (--refc->ref_count == 0) {
-        if (refc->resource_type) {
-            if (refc->resource_type->down) {
-                // There may be monitors associated with this resource.
-                destroy_resource_monitors(refc, global);
-                // After this point, the resource can no longer be found by
-                // resource_type_fire_monitor
-                // However, resource_type_fire_monitor may have incremented ref_count
-                // to call the monitor handler.
-                // So we check ref_count again. We're not affected by the ABA problem
-                // here as the resource cannot (should not) be monitoring while it is
-                // being destroyed, i.e. no resource monitor will be created now
-                if (UNLIKELY(refc->ref_count != 0)) {
-                    return false;
-                }
-            }
-            // Remove the resource from the list of serialized resources
-            // so it no longer can be unserialized.
-            resource_unmark_serialized(refc->data, refc->resource_type);
+    if (!refc->resource_type) {
+        // Plain refc binary: the full word is the reference count.
+        size_t new_val = refc_binary_sub_refcount(refc, 1);
+        if (new_val == 0) {
+            synclist_remove(&global->refc_binaries, &refc->head);
+            refc_binary_destroy(refc, global);
+            return true;
         }
-        synclist_remove(&global->refc_binaries, &refc->head);
-        refc_binary_destroy(refc, global);
+        return false;
+    }
+
+    // Resource: ref count is in the packed lower bits.
+    size_t new_val = refc_binary_sub_refcount(refc, 1);
+    if ((new_val & REFC_COUNT_MASK) == 0) {
+        if (refc->resource_type->down) {
+            // Sets dying flag and removes monitors from resource_type list.
+            destroy_resource_monitors(refc, global);
+            // Atomically claim the free: only the thread that CASes
+            // REFC_DYING_FLAG -> 0 calls refc_binary_free_resource.
+            // resource_type_fire_monitor uses the same CAS if it is last.
+            size_t expected = REFC_DYING_FLAG;
+            if (!refc_binary_cas_refcount(refc, &expected, 0)) {
+                return false;
+            }
+        }
+        refc_binary_free_resource(refc, global);
         return true;
     }
     return false;
@@ -104,6 +108,13 @@ void refc_binary_destroy(struct RefcBinary *refc, struct GlobalContext *global)
         }
     }
     free(refc);
+}
+
+void refc_binary_free_resource(struct RefcBinary *refc, GlobalContext *global)
+{
+    resource_unmark_serialized(refc->data, refc->resource_type);
+    synclist_remove(&global->refc_binaries, &refc->head);
+    refc_binary_destroy(refc, global);
 }
 
 term refc_binary_create_binary_info(Context *ctx)
@@ -127,7 +138,7 @@ term refc_binary_create_binary_info(Context *ctx)
         struct RefcBinary *refc = GET_LIST_ENTRY(item, struct RefcBinary, head);
         term t = term_alloc_tuple(2, &ctx->heap);
         term_put_tuple_element(t, 0, term_from_int(refc->size));
-        term_put_tuple_element(t, 1, term_from_int(refc->ref_count));
+        term_put_tuple_element(t, 1, term_from_int(refc_binary_get_refcount(refc)));
         ret = term_list_prepend(t, ret, &ctx->heap);
     }
     synclist_unlock(&ctx->global->refc_binaries);
@@ -206,7 +217,7 @@ COLD_FUNC void refc_binary_dump_info(Context *ctx)
             top_indices[i],
             (int) refc->size,
             (double) refc->size * 100.0 / (double) total_size,
-            (int) refc->ref_count);
+            (int) refc_binary_get_refcount(refc));
 
         if (refc->resource_type) {
             fprintf(stderr, " [resource]");

--- a/src/libAtomVM/refc_binary.h
+++ b/src/libAtomVM/refc_binary.h
@@ -55,11 +55,96 @@ typedef struct GlobalContext GlobalContext;
 struct RefcBinary
 {
     struct ListHead head;
+    // For resources (resource_type != NULL), this word is packed:
+    //   [dying:1 | monitor_refc:7/15 | ref_count:24/48]
+    // (7+24 on 32-bit, 15+48 on 64-bit).
     size_t ATOMIC ref_count;
     size_t size;
     struct ResourceType *resource_type; // Resource type or NULL for regular refc binaries.
     uint8_t data[];
 };
+
+#define REFC_COUNT_BITS (sizeof(size_t) * 6)
+#define REFC_COUNT_MASK (((size_t) 1 << REFC_COUNT_BITS) - 1)
+#define REFC_MONITOR_INC ((size_t) 1 << REFC_COUNT_BITS)
+#define REFC_DYING_FLAG ((size_t) 1 << (sizeof(size_t) * 8 - 1))
+#define REFC_MONITOR_MASK (~REFC_COUNT_MASK & ~REFC_DYING_FLAG)
+#define REFC_MONITOR_MAX ((REFC_DYING_FLAG >> REFC_COUNT_BITS) - 1)
+
+#ifndef __cplusplus
+#if !defined(AVM_NO_SMP) && !defined(HAVE_ATOMIC) && !defined(HAVE_PLATFORM_ATOMIC_H)
+#error "SMP build requires either C11 atomics (HAVE_ATOMIC) or a platform atomic header (HAVE_PLATFORM_ATOMIC_H)"
+#endif
+
+static inline size_t refc_binary_sub_refcount(struct RefcBinary *refc, size_t delta)
+{
+#if defined(AVM_NO_SMP)
+    return (refc->ref_count -= delta);
+#elif defined(HAVE_ATOMIC)
+    return atomic_fetch_sub(&refc->ref_count, delta) - delta;
+#else // HAVE_PLATFORM_ATOMIC_H guaranteed by #error above
+    return smp_atomic_fetch_sub_size(&refc->ref_count, delta) - delta;
+#endif
+}
+
+static inline void refc_binary_add_refcount(struct RefcBinary *refc, size_t delta)
+{
+#if defined(AVM_NO_SMP)
+    refc->ref_count += delta;
+#elif defined(HAVE_ATOMIC)
+    atomic_fetch_add(&refc->ref_count, delta);
+#else // HAVE_PLATFORM_ATOMIC_H guaranteed by #error above
+    smp_atomic_fetch_add_size(&refc->ref_count, delta);
+#endif
+}
+
+static inline void refc_binary_or_refcount(struct RefcBinary *refc, size_t mask)
+{
+#if defined(AVM_NO_SMP)
+    refc->ref_count |= mask;
+#elif defined(HAVE_ATOMIC)
+    atomic_fetch_or(&refc->ref_count, mask);
+#else // HAVE_PLATFORM_ATOMIC_H guaranteed by #error above
+    smp_atomic_fetch_or_size(&refc->ref_count, mask);
+#endif
+}
+
+// Attempt to atomically transition ref_count from *expected to desired.
+// Returns true on success; on failure updates *expected to the current value.
+// Used to claim the sole right to call refc_binary_free_resource.
+static inline bool refc_binary_cas_refcount(struct RefcBinary *refc, size_t *expected, size_t desired)
+{
+#if defined(AVM_NO_SMP)
+    if (refc->ref_count == *expected) {
+        refc->ref_count = desired;
+        return true;
+    }
+    *expected = refc->ref_count;
+    return false;
+#elif defined(HAVE_ATOMIC)
+    return atomic_compare_exchange_strong(&refc->ref_count, expected, desired);
+#else // HAVE_PLATFORM_ATOMIC_H guaranteed by #error above
+    return ATOMIC_COMPARE_EXCHANGE_WEAK_INT(&refc->ref_count, expected, desired);
+#endif
+}
+#endif // __cplusplus
+
+// Return the user-visible reference count: lower REFC_COUNT_BITS bits for
+// resources (resource_type != NULL), full word for plain refc binaries.
+static inline size_t refc_binary_get_refcount(const struct RefcBinary *refc)
+{
+    return refc->resource_type ? (refc->ref_count & REFC_COUNT_MASK) : refc->ref_count;
+}
+
+/**
+ * @brief Unmark, remove from global list, and free a resource RefcBinary.
+ *
+ * @details Equivalent to resource_unmark_serialized + synclist_remove +
+ * refc_binary_destroy. Only valid when resource_type != NULL.
+ * @param refc the resource binary to free
+ * @param global the global context
+ */
+void refc_binary_free_resource(struct RefcBinary *refc, GlobalContext *global);
 
 /**
  * @brief Create a reference-counted resource object outside of the process heap

--- a/src/libAtomVM/resources.c
+++ b/src/libAtomVM/resources.c
@@ -405,7 +405,20 @@ int enif_monitor_process(ErlNifEnv *env, void *obj, const ErlNifPid *target_pid,
         return 1;
     }
 
-    synclist_append(&resource_type->monitors, &resource_monitor->resource_list_head);
+    // Definitive overflow check and append+increment under the monitors lock
+    // so two concurrent callers cannot both pass and overflow monitor_refc.
+    struct ListHead *monitor_list = synclist_wrlock(&resource_type->monitors);
+    if (UNLIKELY(((resource->ref_count & REFC_MONITOR_MASK) >> REFC_COUNT_BITS) >= REFC_MONITOR_MAX)) {
+        synclist_unlock(&resource_type->monitors);
+        free(resource_monitor);
+        struct ResourceContextMonitor *resource_context_monitor = CONTAINER_OF(monitor, struct ResourceContextMonitor, monitor);
+        free(resource_context_monitor);
+        globalcontext_get_process_unlock(env->global, target);
+        return -1;
+    }
+    list_append(monitor_list, &resource_monitor->resource_list_head);
+    refc_binary_add_refcount(resource, REFC_MONITOR_INC);
+    synclist_unlock(&resource_type->monitors);
     mailbox_send_monitor_signal(target, MonitorSignal, monitor);
     globalcontext_get_process_unlock(env->global, target);
 
@@ -420,14 +433,14 @@ int enif_monitor_process(ErlNifEnv *env, void *obj, const ErlNifPid *target_pid,
 void resource_type_fire_monitor(struct ResourceType *resource_type, ErlNifEnv *env, int32_t process_id, uint64_t ref_ticks)
 {
     struct RefcBinary *refc = NULL;
+    bool is_dying = false;
     struct ListHead *monitors = synclist_wrlock(&resource_type->monitors);
     struct ListHead *item;
     LIST_FOR_EACH (item, monitors) {
         struct ResourceMonitor *monitor = GET_LIST_ENTRY(item, struct ResourceMonitor, resource_list_head);
         if (monitor->ref_ticks == ref_ticks) {
-            // Resource still exists.
             refc = monitor->resource;
-            refc_binary_increment_refcount(refc);
+            is_dying = refc->ref_count & REFC_DYING_FLAG;
             list_remove(&monitor->resource_list_head);
             free(monitor);
             break;
@@ -436,12 +449,26 @@ void resource_type_fire_monitor(struct ResourceType *resource_type, ErlNifEnv *e
 
     synclist_unlock(&resource_type->monitors);
 
-    if (refc) {
+    if (refc == NULL) {
+        return;
+    }
+
+    if (!is_dying) {
         ErlNifMonitor monitor;
         monitor.ref_ticks = ref_ticks;
         monitor.resource_type = resource_type;
         resource_type->down(env, refc->data, &process_id, &monitor);
-        refc_binary_decrement_refcount(refc, env->global);
+    }
+
+    // Balance the increment from enif_monitor_process.
+    size_t val = refc_binary_sub_refcount(refc, REFC_MONITOR_INC);
+    if ((val & REFC_DYING_FLAG) && !(val & REFC_MONITOR_MASK)) {
+        // CAS REFC_DYING_FLAG -> 0 to claim the free; the decrement path
+        // in refc_binary_decrement_refcount uses the same claim.
+        size_t expected = REFC_DYING_FLAG;
+        if (refc_binary_cas_refcount(refc, &expected, 0)) {
+            refc_binary_free_resource(refc, env->global);
+        }
     }
 }
 
@@ -477,13 +504,14 @@ int enif_demonitor_process(ErlNifEnv *env, void *obj, const ErlNifMonitor *mon)
     int32_t target_process_id = INVALID_PROCESS_ID;
     uint64_t ref_ticks = 0;
 
+    struct RefcBinary *resource = refc_binary_from_data(obj);
+
     // Phase 1: Find and remove from monitors list while holding monitors lock
     struct ListHead *monitors = synclist_wrlock(&resource_type->monitors);
     struct ListHead *item;
     LIST_FOR_EACH (item, monitors) {
         struct ResourceMonitor *monitor = GET_LIST_ENTRY(item, struct ResourceMonitor, resource_list_head);
         if (monitor->ref_ticks == mon->ref_ticks) {
-            struct RefcBinary *resource = refc_binary_from_data(obj);
             if (resource->resource_type != mon->resource_type) {
                 synclist_unlock(&resource_type->monitors);
                 return -1;
@@ -492,6 +520,7 @@ int enif_demonitor_process(ErlNifEnv *env, void *obj, const ErlNifMonitor *mon)
             target_process_id = monitor->process_id;
             ref_ticks = monitor->ref_ticks;
             list_remove(&monitor->resource_list_head);
+            (void) refc_binary_sub_refcount(resource, REFC_MONITOR_INC);
             free(monitor);
             break;
         }
@@ -517,11 +546,14 @@ void destroy_resource_monitors(struct RefcBinary *resource, GlobalContext *globa
 {
     struct ResourceType *resource_type = resource->resource_type;
 
-    // Phase 1: Collect monitors to destroy while holding monitors lock
+    // Phase 1: Mark dying and collect monitors while holding the lock.
+    // The dying flag prevents concurrent resource_type_fire_monitor from
+    // calling down on a resource whose ref_count has reached 0.
     struct ListHead to_signal;
     list_init(&to_signal);
 
     struct ListHead *monitors = synclist_wrlock(&resource_type->monitors);
+    refc_binary_or_refcount(resource, REFC_DYING_FLAG);
     struct ListHead *item;
     struct ListHead *tmp;
     MUTABLE_LIST_FOR_EACH (item, tmp, monitors) {
@@ -533,8 +565,7 @@ void destroy_resource_monitors(struct RefcBinary *resource, GlobalContext *globa
     }
     synclist_unlock(&resource_type->monitors);
 
-    // Phase 2: Send demonitor signals without holding monitors lock
-    // This avoids lock order inversion with processes_table
+    // Phase 2: Send demonitor signals without holding monitors lock.
     MUTABLE_LIST_FOR_EACH (item, tmp, &to_signal) {
         struct ResourceMonitor *monitor = GET_LIST_ENTRY(item, struct ResourceMonitor, resource_list_head);
         Context *target = globalcontext_get_process_lock(global, monitor->process_id);
@@ -543,6 +574,7 @@ void destroy_resource_monitors(struct RefcBinary *resource, GlobalContext *globa
             globalcontext_get_process_unlock(global, target);
         }
         list_remove(&monitor->resource_list_head);
+        (void) refc_binary_sub_refcount(resource, REFC_MONITOR_INC);
         free(monitor);
     }
 }

--- a/src/libAtomVM/term.c
+++ b/src/libAtomVM/term.c
@@ -1383,7 +1383,7 @@ term term_from_resource_binary_pointer(struct ResourceBinary *resource, size_t s
     boxed_value[3] = (term) refc;
     term ret = ((term) boxed_value) | TERM_PRIMARY_BOXED;
     // Add the resource to the mso list
-    refc->ref_count++;
+    refc_binary_add_refcount(refc, 1);
     heap->root->mso_list = term_list_init_prepend(boxed_value + REFC_BINARY_CONS_OFFSET, ret, heap->root->mso_list);
     refc_binary_increment_refcount(resource->managing_resource);
     return ret;

--- a/src/libAtomVM/term.h
+++ b/src/libAtomVM/term.h
@@ -2989,7 +2989,7 @@ static inline term term_from_resource(void *resource, Heap *heap)
     boxed_value[0] = TERM_BOXED_REFERENCE_RESOURCE_HEADER;
     boxed_value[1] = (term) refc;
     // Add the resource to the mso list
-    refc->ref_count++;
+    refc_binary_add_refcount(refc, 1);
     term ret = ((term) boxed_value) | TERM_PRIMARY_BOXED;
     heap->root->mso_list = term_list_init_prepend(boxed_value + REFERENCE_RESOURCE_CONS_OFFSET, ret, heap->root->mso_list);
     return ret;

--- a/src/platforms/rp2/src/lib/platform_atomic.h
+++ b/src/platforms/rp2/src/lib/platform_atomic.h
@@ -150,4 +150,38 @@ static inline bool smp_atomic_compare_exchange_weak_int(void *object, void *expe
     return result;
 }
 
+// fetch-and-modify helpers for size_t, used by refc_binary.h on RP2040 where
+// C11 _Atomic is not available. All three use the same critical section as the
+// CAS operations above to provide a coherent memory model across cores.
+// Only meaningful for SMP builds; in no-SMP builds the refc_binary.h helpers
+// use plain C operators instead of calling these functions.
+#ifndef AVM_NO_SMP
+static inline size_t smp_atomic_fetch_add_size(size_t *object, size_t delta)
+{
+    critical_section_enter_blocking(&atomic_cas_section);
+    size_t old = *object;
+    *object = old + delta;
+    critical_section_exit(&atomic_cas_section);
+    return old;
+}
+
+static inline size_t smp_atomic_fetch_sub_size(size_t *object, size_t delta)
+{
+    critical_section_enter_blocking(&atomic_cas_section);
+    size_t old = *object;
+    *object = old - delta;
+    critical_section_exit(&atomic_cas_section);
+    return old;
+}
+
+static inline size_t smp_atomic_fetch_or_size(size_t *object, size_t mask)
+{
+    critical_section_enter_blocking(&atomic_cas_section);
+    size_t old = *object;
+    *object = old | mask;
+    critical_section_exit(&atomic_cas_section);
+    return old;
+}
+#endif // AVM_NO_SMP
+
 #endif

--- a/tests/test-enif.c
+++ b/tests/test-enif.c
@@ -41,20 +41,27 @@ static ErlNifMonitor down_mon_two = { NULL, 0 };
 
 static int32_t lockable_pid = 0;
 
-// Helper to get the reference count.
-// Uses an internal API
-// Implementation should be updated shall resources be references instead of binaries.
-static uint32_t resource_ref_count(void *resource)
+// Helpers for resource ref_count sub-fields (packed layout).
+// Only valid for resources, not plain refc binaries.
+static size_t resource_ref_count(void *resource)
+{
+    return refc_binary_get_refcount(refc_binary_from_data(resource));
+}
+
+static size_t resource_monitor_refc(void *resource)
 {
     struct RefcBinary *refc = refc_binary_from_data(resource);
-    return refc->ref_count;
+    return (refc->ref_count & REFC_MONITOR_MASK) >> REFC_COUNT_BITS;
 }
+
+static uint32_t dtor_call_count = 0;
 
 static void resource_dtor(ErlNifEnv *env, void *resource)
 {
     UNUSED(env);
 
     cb_read_resource = *((uint32_t *) resource);
+    dtor_call_count++;
 }
 
 static void resource_down(ErlNifEnv *env, void *resource, ErlNifPid *pid, ErlNifMonitor *mon)
@@ -73,6 +80,18 @@ static void resource_down_two(ErlNifEnv *env, void *resource, ErlNifPid *pid, Er
     cb_read_resource_two = *((uint32_t *) resource);
     down_pid_two = *pid;
     down_mon_two = *mon;
+}
+
+// Simulates the race: release resource from within the down handler.
+static void resource_down_releasing(ErlNifEnv *env, void *resource, ErlNifPid *pid, ErlNifMonitor *mon)
+{
+    UNUSED(env);
+
+    cb_read_resource = *((uint32_t *) resource);
+    down_pid = *pid;
+    down_mon = *mon;
+
+    enif_release_resource(resource);
 }
 
 // down handlers should be able to acquire the process tables lock, e.g. to send
@@ -249,18 +268,21 @@ void test_resource_monitor(void)
     cb_read_resource = 0;
     down_pid = 0;
     down_mon.ref_ticks = 0;
+    assert(resource_monitor_refc(ptr) == 0);
     ctx = context_new(glb);
     pid = ctx->process_id;
     monitor_result = enif_monitor_process(&env, ptr, &pid, &mon);
     assert(monitor_result == 0);
     assert(cb_read_resource == 0);
     assert(resource_ref_count(ptr) == 1);
+    assert(resource_monitor_refc(ptr) == 1);
 
     scheduler_terminate(ctx);
     assert(cb_read_resource == 42);
     assert(down_pid == pid);
     assert(enif_compare_monitors(&mon, &down_mon) == 0);
     assert(resource_ref_count(ptr) == 1);
+    assert(resource_monitor_refc(ptr) == 0);
 
     // Monitor not called if demonitored
     cb_read_resource = 0;
@@ -272,10 +294,12 @@ void test_resource_monitor(void)
     assert(monitor_result == 0);
     assert(cb_read_resource == 0);
     assert(resource_ref_count(ptr) == 1);
+    assert(resource_monitor_refc(ptr) == 1);
 
     monitor_result = enif_demonitor_process(&env, ptr, &mon);
     assert(monitor_result == 0);
     assert(resource_ref_count(ptr) == 1);
+    assert(resource_monitor_refc(ptr) == 0);
 
     scheduler_terminate(ctx);
     assert(cb_read_resource == 0);
@@ -582,6 +606,114 @@ void test_resource_binaries(void)
     assert(cb_read_resource == 0);
 }
 
+// Exercises the exact race that caused double-free: the down handler releases
+// the resource (dropping ref_count to 0) while resource_type_fire_monitor is
+// still on the stack. The monitor_refc mechanism defers destruction until
+// fire_monitor completes.
+void test_resource_release_in_down_handler(void)
+{
+    GlobalContext *glb = globalcontext_new();
+    ErlNifEnv env;
+    erl_nif_env_partial_init_from_globalcontext(&env, glb);
+
+    ErlNifResourceTypeInit init;
+    init.members = 3;
+    init.dtor = resource_dtor;
+    init.stop = NULL;
+    init.down = resource_down_releasing;
+    ErlNifResourceFlags flags;
+
+    ErlNifResourceType *resource_type = enif_init_resource_type(&env, "test_resource", &init, ERL_NIF_RT_CREATE, &flags);
+    assert(resource_type != NULL);
+
+    void *ptr = enif_alloc_resource(resource_type, sizeof(uint32_t));
+    uint32_t *resource = (uint32_t *) ptr;
+    *resource = 42;
+
+    cb_read_resource = 0;
+    dtor_call_count = 0;
+    down_pid = 0;
+    down_mon.ref_ticks = 0;
+
+    Context *ctx = context_new(glb);
+    int32_t pid = ctx->process_id;
+    ErlNifMonitor mon;
+    int monitor_result = enif_monitor_process(&env, ptr, &pid, &mon);
+    assert(monitor_result == 0);
+    assert(resource_ref_count(ptr) == 1);
+    assert(resource_monitor_refc(ptr) == 1);
+
+    // Process dies → fire_monitor → down_releasing → enif_release_resource.
+    // ref_count hits 0 inside down, but monitor_refc prevents immediate free.
+    // After down returns, fire_monitor decrements monitor_refc to 0 and
+    // completes deferred destruction.
+    scheduler_terminate(ctx);
+
+    assert(down_pid == pid);
+    assert(enif_compare_monitors(&mon, &down_mon) == 0);
+    assert(dtor_call_count == 1);
+    assert(cb_read_resource == 42);
+
+    globalcontext_destroy(glb);
+}
+
+// Same as above but with two monitors: both processes die, the first down
+// handler releases the resource. The second down must NOT be called.
+void test_resource_release_in_down_handler_two_monitors(void)
+{
+    GlobalContext *glb = globalcontext_new();
+    ErlNifEnv env;
+    erl_nif_env_partial_init_from_globalcontext(&env, glb);
+
+    ErlNifResourceTypeInit init;
+    init.members = 3;
+    init.dtor = resource_dtor;
+    init.stop = NULL;
+    init.down = resource_down_releasing;
+    ErlNifResourceFlags flags;
+
+    ErlNifResourceType *resource_type = enif_init_resource_type(&env, "test_resource", &init, ERL_NIF_RT_CREATE, &flags);
+    assert(resource_type != NULL);
+
+    void *ptr = enif_alloc_resource(resource_type, sizeof(uint32_t));
+    uint32_t *resource = (uint32_t *) ptr;
+    *resource = 42;
+
+    cb_read_resource = 0;
+    dtor_call_count = 0;
+    down_pid = 0;
+
+    Context *ctx1 = context_new(glb);
+    Context *ctx2 = context_new(glb);
+    int32_t pid1 = ctx1->process_id;
+    int32_t pid2 = ctx2->process_id;
+    ErlNifMonitor mon1, mon2;
+
+    int r = enif_monitor_process(&env, ptr, &pid1, &mon1);
+    assert(r == 0);
+    r = enif_monitor_process(&env, ptr, &pid2, &mon2);
+    assert(r == 0);
+    assert(resource_monitor_refc(ptr) == 2);
+
+    // First process dies: down is called, releases resource (ref_count→0).
+    // destroy_resource_monitors cancels the second monitor (monitor_refc 2→1).
+    // After down returns, fire_monitor decrements monitor_refc (1→0) and
+    // completes deferred destruction (dtor + free).
+    scheduler_terminate(ctx1);
+    assert(down_pid == pid1);
+    assert(dtor_call_count == 1);
+    assert(cb_read_resource == 42);
+
+    // Second process dies: no monitors left so fire_monitor is a no-op.
+    down_pid = 0;
+    dtor_call_count = 0;
+    scheduler_terminate(ctx2);
+    assert(down_pid == 0);
+    assert(dtor_call_count == 0);
+
+    globalcontext_destroy(glb);
+}
+
 int main(int argc, char **argv)
 {
     UNUSED(argc);
@@ -595,6 +727,8 @@ int main(int argc, char **argv)
     test_resource_monitor_two_resources_two_processes();
     test_resource_binary();
     test_resource_binaries();
+    test_resource_release_in_down_handler();
+    test_resource_release_in_down_handler_two_monitors();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved atomic-safe reference counting and packed refcount handling for resource-backed binaries to avoid races and ensure correct lifecycle transitions.
  * Strengthened monitor accounting and overflow protection; ensured orderly state transitions and deferred cleanup when resources are released during monitor/down callbacks.

* **Tests**
  * Added tests covering race conditions, monitor interactions, and deferred destruction to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->