### PR TITLE
Fix flaky test_net_kernel segfault: handle socket errors and fix JIT byte_size

### DIFF
--- a/libs/estdlib/src/socket_dist_controller.erl
+++ b/libs/estdlib/src/socket_dist_controller.erl
@@ -182,7 +182,11 @@ recv_data_loop(
             ),
             State#state{buffer = NewBuffer, select_handle = SelectHandle, received = NewReceived};
         {select, {select_info, recv, SelectHandle}} when is_reference(SelectHandle) ->
-            State#state{select_handle = SelectHandle}
+            State#state{select_handle = SelectHandle};
+        {error, closed} ->
+            exit(normal);
+        {error, Reason} ->
+            exit({recv_error, Reason})
     end.
 
 process_recv_buffer(DHandle, <<Size:32, Rest/binary>>, Received) when byte_size(Rest) >= Size ->

--- a/libs/jit/src/jit.erl
+++ b/libs/jit/src/jit.erl
@@ -3269,8 +3269,11 @@ op_gc_bif1_byte_size_binary(MMod, MSt0, Arg, Dest) ->
     MSt6 = MMod:move_to_vm_register(MSt5, Reg, Dest),
     MMod:free_native_registers(MSt6, [Reg, Dest]).
 
-is_known_binary(_MMod, _MSt, {typed, _Arg, {t_bs_matchable, Unit}}) when Unit rem 8 =:= 0 ->
-    true;
+is_known_binary(_MMod, _MSt, {typed, _Arg, {t_bs_matchable, _Unit}}) ->
+    % t_bs_matchable can be either a binary or a match state.
+    % Match states have a different layout (boxed_value[1] is the original
+    % binary term, not a size), so we cannot safely inline byte_size here.
+    false;
 is_known_binary(_MMod, _MSt, _) ->
     false.
 

--- a/tests/erlang_tests/CMakeLists.txt
+++ b/tests/erlang_tests/CMakeLists.txt
@@ -122,6 +122,7 @@ compile_erlang(send_receive)
 compile_erlang(send_to_dead_process)
 compile_erlang(selval)
 compile_erlang(byte_size_test)
+compile_erlang(test_byte_size_match_state)
 compile_erlang(tuple)
 compile_erlang(count_char)
 compile_erlang(len_test)
@@ -670,6 +671,7 @@ set(erlang_test_beams
     send_to_dead_process.beam
     selval.beam
     byte_size_test.beam
+    test_byte_size_match_state.beam
     tuple.beam
     count_char.beam
     len_test.beam

--- a/tests/erlang_tests/test_byte_size_match_state.erl
+++ b/tests/erlang_tests/test_byte_size_match_state.erl
@@ -1,0 +1,52 @@
+%
+% This file is part of AtomVM.
+%
+% Copyright 2026 Paul Guyot <pguyot@kallisys.net>
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%    http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+%
+% SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
+%
+
+%% Test byte_size/1 on values that may be typed as t_bs_matchable by
+%% the compiler (i.e. values that could be either binaries or match
+%% states at runtime). This exercises the JIT inline byte_size
+%% optimization to ensure it correctly handles match states.
+
+-module(test_byte_size_match_state).
+
+-export([start/0, byte_size_during_match/1, byte_size_of_alias/1, byte_size_after_submatch/1]).
+
+start() ->
+    10 = byte_size_during_match(<<"hello world">>),
+    11 = byte_size_of_alias(<<"hello world">>),
+    3 = byte_size_after_submatch(<<1, 2, 3, 4, 5>>),
+    % Return expected value: 10 + 11 + 3 = 24
+    byte_size_during_match(<<"hello world">>) +
+        byte_size_of_alias(<<"hello world">>) +
+        byte_size_after_submatch(<<1, 2, 3, 4, 5>>).
+
+%% Call byte_size on the matched rest binary.
+%% The compiler may keep Rest as a match state internally.
+byte_size_during_match(<<_:8, Rest/binary>>) ->
+    byte_size(Rest).
+
+%% Call byte_size on the original binary that is aliased
+%% with a pattern match. The compiler may internally replace
+%% Bin with the match state from the binary match.
+byte_size_of_alias(<<_H:8, _/binary>> = Bin) ->
+    byte_size(Bin).
+
+%% Call byte_size on a sub-binary from a nested match context.
+byte_size_after_submatch(<<_:8, _:8, Rest/binary>>) ->
+    byte_size(Rest).

--- a/tests/test.c
+++ b/tests/test.c
@@ -116,6 +116,7 @@ struct Test tests[] = {
     TEST_CASE_EXPECTED(send_to_dead_process, 20),
     TEST_CASE(selval),
     TEST_CASE_EXPECTED(byte_size_test, 10),
+    TEST_CASE_EXPECTED(test_byte_size_match_state, 24),
     TEST_CASE_EXPECTED(tuple, 6),
     TEST_CASE_EXPECTED(len_test, 5),
     TEST_CASE_EXPECTED(count_char, 2),


### PR DESCRIPTION
## Summary

- Fix unhandled `{error, closed}` return from `socket:recv/3` in `socket_dist_controller:recv_data_loop/1` that causes a `case_clause` crash when a distribution connection is closed. The crash cascades to many processes crashing simultaneously, which can trigger a segfault in dist_connection resource cleanup.
- Fix incorrect JIT inline `byte_size/1` optimization for `t_bs_matchable` typed values. The `is_known_binary` predicate treated all `t_bs_matchable` values as binaries, but this type also includes match states which have a different memory layout (`boxed_value[1]` is the original binary term, not the byte size). Falls back to the safe C implementation.

## Investigation

CI failure: https://github.com/atomvm/AtomVM/actions/runs/23432278077/job/68161379169

The failing job is `build-and-test (macos-15-intel, 28, mbedtls@3, -DAVM_DISABLE_JIT=OFF)` which crashes with SIGSEGV (exit code 139) during `test_net_kernel` in `test_estdlib.avm`.

**Crash sequence:**
1. Distribution connection handshake fails with `invalid_challenge`
2. `socket_dist_controller:recv_data_loop/1` gets `{error, closed}` from `socket:recv/3`
3. Unhandled case clause causes `socket_dist_controller` to crash abnormally
4. This cascades to many `erpc:execute_call` processes and other dist controllers crashing simultaneously
5. The chaotic concurrent cleanup of dist_connection resources triggers a segfault

**Fix 1 - socket_dist_controller (commit 1):** `recv_data_loop/1` only handled `{ok, Data}` and `{select, ...}` but not error tuples. When the remote side closes the connection, `socket:recv` returns `{error, closed}`, and the missing clause causes an abnormal crash instead of a graceful shutdown. Now handles `{error, closed}` with `exit(normal)` and `{error, Reason}` with `exit({recv_error, Reason})`.

**Fix 2 - JIT byte_size inline (commit 2):** The `is_known_binary` predicate in `jit.erl` matched `{t_bs_matchable, Unit}` typed values for inline `byte_size/1`. However, `t_bs_matchable` can be either a binary or a match state. Match states store the original binary term (a tagged pointer) in `boxed_value[1]`, not a size value. The inline code reads `boxed_value[1]` as a raw integer size, which would produce garbage or crash on match states. The C implementation in `bif.c` (line 107-121) correctly handles both cases. Now disabled for `t_bs_matchable` to fall back to the safe C path.

## Test plan

- [ ] Verify `test_net_kernel` passes on macOS Intel with JIT enabled
- [ ] Verify no regressions in other distribution tests
- [ ] Verify JIT byte_size still works correctly for non-matchable binaries
- [ ] Monitor CI for recurrence of the flaky segfault

https://claude.ai/code/session_0171oFtto9aUZnK2BdFMr8Qq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved socket error handling: closed and error conditions are now explicitly handled to ensure proper process termination and clearer error reporting for socket-based communication.

* **Performance / Runtime Behavior**
  * Adjusted a JIT optimization for certain typed binary patterns: a previous fast-path optimization is disabled, opting for a safer fallback implementation (may affect performance in some cases).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->